### PR TITLE
Add timestamp to CommonArgs type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,7 +118,9 @@ export interface ConnectOptions {
     NETWORK_BYTE: number;
 }
 
-type CommonArgs = Partial<Pick<BaseTransaction, 'fee' | 'senderPublicKey'>> & {
+type CommonArgs = Partial<
+    Pick<BaseTransaction, 'fee' | 'senderPublicKey' | 'timestamp'>
+> & {
     proofs?: Proofs;
 } & { version?: number };
 


### PR DESCRIPTION
Right now it's not allowed to pass `timestamp` with transaction, but it can be useful to limit the time frame in which transaction would be accepted by node. Plus both ProviderWeb and ProviderCloud actually allow it to be passed.